### PR TITLE
fix(minimapicons): harden icon rendering null safety

### DIFF
--- a/IconsBuilder/Icons/BaseIcon.cs
+++ b/IconsBuilder/Icons/BaseIcon.cs
@@ -38,12 +38,7 @@ public abstract class BaseIcon
 
     public BaseIcon(Entity entity)
     {
-        Entity = entity;
-
-        if (Entity == null)
-        {
-            return;
-        }
+        Entity = entity ?? throw new ArgumentNullException(nameof(entity));
 
         Rarity = Entity.Rarity;
 
@@ -92,13 +87,13 @@ public abstract class BaseIcon
     public bool HasIngameIcon => _HasIngameIcon;
     public Entity Entity { get; }
 
-    public Func<Vector2> GridPosition { get; set; }
+    public Func<Vector2> GridPosition { get; set; } = () => Vector2.Zero;
     public RectangleF DrawRect { get; set; }
-    public Func<bool> Show { get; set; }
+    public Func<bool> Show { get; set; } = () => false;
     public Func<bool> Hidden { get; protected set; } = () => false;
-    public HudTexture MainTexture { get; protected set; }
+    public HudTexture MainTexture { get; protected set; } = new("Icons.png");
     public IconPriority Priority { get; protected set; }
     public MonsterRarity Rarity { get; protected set; }
-    public string Text { get; protected set; }
+    public string Text { get; protected set; } = string.Empty;
     public string RenderName => Entity.RenderName;
 }

--- a/IconsBuilder/Icons/ChestIcon.cs
+++ b/IconsBuilder/Icons/ChestIcon.cs
@@ -46,7 +46,7 @@ public class ChestIcon : BaseIcon
         if (_HasIngameIcon)
         {
             MainTexture.Size = settings.SizeChestIcon;
-            Text = Entity.GetComponent<Render>()?.Name;
+            Text = Entity.GetComponent<Render>()?.Name ?? string.Empty;
             return;
         }
 
@@ -88,12 +88,12 @@ public class ChestIcon : BaseIcon
                 if (strongboxesUV.TryGetValue(Entity.Path, out var result))
                 {
                     MainTexture.UV = SpriteHelper.GetUV(result, new Vector2i(7, 8));
-                    Text = Entity.GetComponent<Render>()?.Name;
+                    Text = Entity.GetComponent<Render>()?.Name ?? string.Empty;
                 }
                 else
                 {
                     MainTexture.UV = SpriteHelper.GetUV(MyMapIconsIndex.Strongbox);
-                    Text = Entity.GetComponent<Render>()?.Name;
+                    Text = Entity.GetComponent<Render>()?.Name ?? string.Empty;
                 }
 
                 break;

--- a/IconsBuilder/Icons/IngameIconReplacerIcon.cs
+++ b/IconsBuilder/Icons/IngameIconReplacerIcon.cs
@@ -37,7 +37,18 @@ public class IngameIconReplacerIcon : BaseIcon
 
         T Update<T>(ref T store, Func<T> update)
         {
-            return entity.IsValid ? store = update() : store;
+            if (!entity.IsValid)
+                return store;
+
+            try
+            {
+                return store = update();
+            }
+            catch
+            {
+                // Component access can fail while the entity is being recycled.
+                return store;
+            }
         }
 
         Show = () => !Update(ref isHidden, () => entity.GetComponent<MinimapIcon>()?.IsHide ?? isHidden) &&
@@ -45,7 +56,16 @@ public class IngameIconReplacerIcon : BaseIcon
                      Update(ref shrineIsAvailable, () => entity.GetComponent<Shrine>()?.IsAvailable ?? shrineIsAvailable) &&
                      !Update(ref isOpened, () => entity.GetComponent<Chest>()?.IsOpened ?? isOpened) &&
                      (!entity.IsValid || mapIconsSettings.AlwaysShownIngameIcons.Content.Any(x => x.Value.Equals(entity.Path)));
-        var name = entity.GetComponent<MinimapIcon>()?.Name ?? "";
+        var name = string.Empty;
+        try
+        {
+            name = entity.GetComponent<MinimapIcon>()?.Name ?? string.Empty;
+        }
+        catch
+        {
+            // Keep the fallback icon stable during entity transitions.
+        }
+
         var iconIndexByName = ExileCore2.Shared.Helpers.Extensions.IconIndexByName(name);
 
         var iconSizeMultiplier = RemoteMemoryObject.TheGame.Files.MinimapIcons.EntriesList.ElementAtOrDefault((int)iconIndexByName)?.LargeMinimapSize ?? 1;

--- a/IconsBuilder/Icons/MonsterIcon.cs
+++ b/IconsBuilder/Icons/MonsterIcon.cs
@@ -35,10 +35,10 @@ public class MonsterIcon : BaseIcon
             MonsterRarity.Magic => settings.SizeEntityMagicIcon,
             MonsterRarity.Rare => settings.SizeEntityRareIcon,
             MonsterRarity.Unique => settings.SizeEntityUniqueIcon,
-            _ => throw new ArgumentException($"{nameof(MonsterIcon)} wrong rarity for {entity.Path}. Dump: {entity.GetComponent<ObjectMagicProperties>().DumpObject()}")
+            _ => throw new ArgumentException($"{nameof(MonsterIcon)} wrong rarity for {entity.Path}. Dump: {(entity.TryGetComponent<ObjectMagicProperties>(out var omp) ? omp.DumpObject() : "ObjectMagicProperties=null")}")
         };
 
-        if (_HasIngameIcon && entity.HasComponent<MinimapIcon>() && !entity.GetComponent<MinimapIcon>().Name.Equals("NPC"))
+        if (_HasIngameIcon && entity.HasComponent<MinimapIcon>() && !string.Equals(entity.GetComponent<MinimapIcon>().Name, "NPC", StringComparison.Ordinal))
             return;
 
         if (!entity.IsHostile)
@@ -52,7 +52,7 @@ public class MonsterIcon : BaseIcon
 
             //Spirits icon
         }
-        else if (Rarity == MonsterRarity.Unique && entity.Path.Contains("Metadata/Monsters/Spirit/"))
+        else if (Rarity == MonsterRarity.Unique && entity.Path?.Contains("Metadata/Monsters/Spirit/") == true)
             MainTexture.UV = SpriteHelper.GetUV(MapIconsIndex.LootFilterLargeGreenHexagon);
         else
         {
@@ -98,7 +98,7 @@ public class MonsterIcon : BaseIcon
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(
-                            $"Rarity wrong was is {Rarity}. {entity.GetComponent<ObjectMagicProperties>().DumpObject()}");
+                            $"Rarity wrong was is {Rarity}. {(entity.TryGetComponent<ObjectMagicProperties>(out var omp2) ? omp2.DumpObject() : "ObjectMagicProperties=null")}");
                 }
             }
         }

--- a/IconsBuilder/Icons/NpcIcon.cs
+++ b/IconsBuilder/Icons/NpcIcon.cs
@@ -14,7 +14,7 @@ public class NpcIcon : BaseIcon
 
         MainTexture.Size = settings.SizeNpcIcon;
         var component = entity.GetComponent<Render>();
-        Text = component?.Name.Split(',')[0];
+        Text = component?.Name.Split(',')[0] ?? string.Empty;
         Show = () => entity.IsValid;
         if (_HasIngameIcon) return;
 

--- a/IconsBuilder/Icons/ShrineIcon.cs
+++ b/IconsBuilder/Icons/ShrineIcon.cs
@@ -12,7 +12,7 @@ public class ShrineIcon : BaseIcon
     {
         MainTexture = new HudTexture("Icons.png");
         MainTexture.UV = SpriteHelper.GetUV(MapIconsIndex.Shrine);
-        Text = entity.GetComponent<Render>()?.Name;
+        Text = entity.GetComponent<Render>()?.Name ?? string.Empty;
         MainTexture.Size = settings.SizeShrineIcon;
         Show = () => entity.IsValid && entity.GetComponent<Shrine>().IsAvailable;
     }

--- a/IconsBuilder/IconsBuilder.cs
+++ b/IconsBuilder/IconsBuilder.cs
@@ -29,7 +29,7 @@ public class IconsBuilder
     private string DefaultIgnoreFile => Path.Combine(_plugin.DirectoryFullName, "config", "ignored_entities.txt");
     private string CustomIgnoreFile => Path.Combine(_plugin.ConfigDirectory, "ignored_entities.txt");
 
-    private List<string> IgnoredEntities { get; set; }
+    private List<string> IgnoredEntities { get; set; } = new List<string>();
     private Dictionary<string, Vector2i> AlertEntitiesWithIconSize { get; set; } = new Dictionary<string, Vector2i>();
 
     private static EntityType[] SkippedEntityTypes =>
@@ -72,6 +72,7 @@ public class IconsBuilder
         if (!File.Exists(path))
         {
            _plugin.LogError($"IconsBuilder -> Ignored entities file does not exist. Path: {path}");
+            IgnoredEntities = new List<string>();
             return;
         }
         IgnoredEntities = File.ReadAllLines(path).Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith('#')).ToList();
@@ -101,7 +102,10 @@ public class IconsBuilder
 
     private void AddIcons()
     {
-        foreach (var entity in _plugin.GameController.Entities)
+        var entities = _plugin.GameController?.Entities;
+        if (entities == null) return;
+
+        foreach (var entity in entities)
         {
             try
             {
@@ -134,7 +138,10 @@ public class IconsBuilder
 
     private BaseIcon GenerateIcon(Entity entity)
     {
-        var metadata = entity.Metadata;
+        if (entity == null || !entity.IsValid)
+            return null;
+
+        var metadata = entity.Metadata ?? string.Empty;
         if (Settings.CustomIcons.Content
                 .FirstOrDefault(x => _regexes.GetValue(x.MetadataRegex.Value, p => new Regex(p))!.IsMatch(metadata)) is { } customIconConfig)
         {
@@ -187,36 +194,50 @@ public class IconsBuilder
         {
             if (!entity.TryGetComponent<Player>(out var player) ||
                 player.PlayerName is not {} playerName ||
-                _plugin.GameController.IngameState.Data.LocalPlayer.Address == entity.Address ||
-                _plugin.GameController.IngameState.Data.LocalPlayer.GetComponent<Render>().Name == entity.RenderName) return null;
+                _plugin.GameController.IngameState.Data.LocalPlayer.Address == entity.Address)
+                return null;
+
+            if (_plugin.GameController.IngameState.Data.LocalPlayer.TryGetComponent<Render>(out var localPlayerRender) &&
+                localPlayerRender.Name == entity.RenderName)
+                return null;
 
             if (!entity.IsValid) return null;
             return new PlayerIcon(entity, Settings, playerName);
         }
 
         //Chests
-        if (entity.Type == EntityType.Chest && !entity.IsOpened)
-            return new ChestIcon(entity, Settings);
+        if (entity.Type == EntityType.Chest)
+        {
+            try
+            {
+                if (!entity.IsOpened)
+                    return new ChestIcon(entity, Settings);
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
         //Area transition
         if (entity.Type == EntityType.AreaTransition)
             return new MiscIcon(entity, Settings);
 
         //Shrine
-        if (entity.HasComponent<Shrine>())
+        if (entity.TryGetComponent<Shrine>(out _))
             return new ShrineIcon(entity, Settings);
 
-        if (entity.HasComponent<Transitionable>() && entity.HasComponent<MinimapIcon>())
+        if (entity.TryGetComponent<Transitionable>(out _) && entity.TryGetComponent<MinimapIcon>(out var minimapIcon))
         {
             //Mission marker
-            if (entity.Path.Equals("Metadata/MiscellaneousObjects/MissionMarker", StringComparison.Ordinal) ||
-                entity.GetComponent<MinimapIcon>().Name.Equals("MissionTarget", StringComparison.Ordinal))
+            if (string.Equals(entity.Path, "Metadata/MiscellaneousObjects/MissionMarker", StringComparison.Ordinal) ||
+                string.Equals(minimapIcon.Name, "MissionTarget", StringComparison.Ordinal))
                 return new MissionMarkerIcon(entity, Settings);
 
             return new MiscIcon(entity, Settings);
         }
 
-        if (entity.HasComponent<MinimapIcon>() && entity.HasComponent<Targetable>() ||
+        if (entity.TryGetComponent<MinimapIcon>(out _) && entity.TryGetComponent<Targetable>(out _) ||
             entity.Path is "Metadata/Terrain/Leagues/Sanctum/Objects/SanctumMote")
             return new MiscIcon(entity, Settings);
 

--- a/MinimapIcons.cs
+++ b/MinimapIcons.cs
@@ -87,25 +87,30 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
 
     public override void Render()
     {
+        var ingameUi = _ingameUi;
+        var gameController = GameController;
         if (_largeMap == null || 
-            !GameController.InGame ||
+            ingameUi == null ||
+            gameController == null ||
+            !gameController.InGame ||
             Settings.DrawOnlyOnLargeMap && _largeMap != true) 
             return;
 
         if (!Settings.IgnoreFullscreenPanels &&
-            _ingameUi.FullscreenPanels.Any(x => x.IsVisible) ||
+            ingameUi.FullscreenPanels.Any(x => x.IsVisible) ||
             !Settings.IgnoreLargePanels &&
-            _ingameUi.LargePanels.Any(x => x.IsVisible))
+            ingameUi.LargePanels.Any(x => x.IsVisible))
             return;
 
-        var playerRender = GameController?.Player?.GetComponent<Render>();
+        var playerRender = gameController.Player?.GetComponent<Render>();
         if (playerRender == null) return;
         var playerPos = playerRender.Pos.WorldToGrid();
         var playerHeight = -playerRender.UnclampedHeight;
+        var ingameData = gameController.IngameState.Data;
 
         if (LargeMapWindow == null) return;
 
-        var baseIcons = _iconListCache.Value;
+        var baseIcons = _iconListCache?.Value;
         if (baseIcons == null) return;
 
         foreach (var icon in baseIcons)
@@ -127,14 +132,14 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
             var iconGridPos = icon.GridPosition();
             var position = _mapCenter +
                            DeltaInWorldToMinimapDelta(iconGridPos - playerPos,
-                               (playerHeight + GameController.IngameState.Data.GetTerrainHeightAt(iconGridPos)) * PoeMapExtension.WorldToGridConversion);
+                               (playerHeight + ingameData.GetTerrainHeightAt(iconGridPos)) * PoeMapExtension.WorldToGridConversion);
 
             var iconValueMainTexture = icon.MainTexture;
             var size = iconValueMainTexture.Size;
             var halfSize = size / 2f;
             icon.DrawRect = new RectangleF(position.X - halfSize, position.Y - halfSize, size, size);
             var drawRect = icon.DrawRect;
-            if (_largeMap == false && !_ingameUi.Map.SmallMiniMap.GetClientRectCache.Contains(drawRect)) 
+            if (_largeMap == false && !ingameUi.Map.SmallMiniMap.GetClientRectCache.Contains(drawRect))
                 continue;
 
             Graphics.DrawImage(iconValueMainTexture.FileName, drawRect, iconValueMainTexture.UV, iconValueMainTexture.Color);


### PR DESCRIPTION
- guard missing game, UI, cache, entity, and component state before dereferencing
- add safe default icon delegates/textures/text to prevent partially initialized icons
- use safer component checks for player, chest, shrine, minimap, and targetable entities