### PR TITLE
refactor(MinimapIcons): revise icon visibility logic for new breach monsters in 0.5.x

### DIFF
--- a/IconsBuilder/Icons/MonsterIcon.cs
+++ b/IconsBuilder/Icons/MonsterIcon.cs
@@ -38,7 +38,7 @@ public class MonsterIcon : BaseIcon
             _ => throw new ArgumentException($"{nameof(MonsterIcon)} wrong rarity for {entity.Path}. Dump: {entity.GetComponent<ObjectMagicProperties>()?.DumpObject()}")
         };
 
-        var isMonsterWithIcon = settings.MonstersWithIcons.Content.Any(x => IconsBuilder.GetRegex(x.Value).IsMatch(entity.Path));
+        var isMonsterWithIcon = IconsBuilder.ShouldTreatAsMonsterWithIcon(entity, settings);
         if (isMonsterWithIcon && IngameIconIndex == MapIconsIndex.BlightMonster)
         {
             MainTexture.Size *= 2;

--- a/IconsBuilder/IconsBuilder.cs
+++ b/IconsBuilder/IconsBuilder.cs
@@ -15,6 +15,7 @@ namespace MinimapIcons.IconsBuilder;
 
 public class IconsBuilder
 {
+    private const string BreachMonsterPathPrefix = "Metadata/Monsters/Breach/Monsters/";
     private readonly MinimapIcons _plugin;
 
     public IconsBuilder(MinimapIcons plugin)
@@ -156,10 +157,11 @@ public class IconsBuilder
             }
         }
 
+        var path = entity.Path ?? string.Empty;
         if (Settings.UseReplacementsForGameIconsWhenOutOfRange &&
             entity.TryGetComponent<MinimapIcon>(out var minimapIconComponent) &&
-            (!minimapIconComponent.IsHide || _plugin.Settings.IgnoreHiddenStatusMinimapIcons.Content.Any(x => GetRegex(x.Value).IsMatch(entity.Path))) && 
-            !Settings.MonstersWithIcons.Content.Any(x => GetRegex(x.Value).IsMatch(entity.Path)))
+            (!minimapIconComponent.IsHide || _plugin.Settings.IgnoreHiddenStatusMinimapIcons.Content.Any(x => GetRegex(x.Value).IsMatch(path))) &&
+            !ShouldTreatAsMonsterWithIcon(path, Settings))
         {
             var name = minimapIconComponent.Name;
             if (!string.IsNullOrEmpty(name))
@@ -227,5 +229,16 @@ public class IconsBuilder
     public static Regex GetRegex(string regex)
     {
         return _regexes.GetValue(regex, p => new Regex(p));
+    }
+
+    public static bool ShouldTreatAsMonsterWithIcon(Entity entity, IconsBuilderSettings settings)
+    {
+        return ShouldTreatAsMonsterWithIcon(entity.Path ?? string.Empty, settings);
+    }
+
+    public static bool ShouldTreatAsMonsterWithIcon(string path, IconsBuilderSettings settings)
+    {
+        return path.StartsWith(BreachMonsterPathPrefix, StringComparison.Ordinal) ||
+               settings.MonstersWithIcons.Content.Any(x => GetRegex(x.Value).IsMatch(path));
     }
 }

--- a/MinimapIcons.cs
+++ b/MinimapIcons.cs
@@ -118,10 +118,7 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
             if (!icon.Show())
                 continue;
 
-            if (icon.HasIngameIcon &&
-                icon is not CustomIcon &&
-                (!Settings.DrawReplacementsForGameIconsWhenOutOfRange || icon.Entity.IsValid) &&
-                !Settings.AlwaysShownIngameIcons.Content.Any(x => global::MinimapIcons.IconsBuilder.IconsBuilder.GetRegex(x.Value).IsMatch(icon.Entity.Path)))
+            if (ShouldSkipIngameIcon(icon))
                 continue;
 
             var iconGridPos = icon.GridPosition();
@@ -166,6 +163,19 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
     private Vector2 DeltaInWorldToMinimapDelta(Vector2 delta, float deltaZ)
     {
         return _mapScale * Vector2.Multiply(new Vector2(delta.X - delta.Y, deltaZ - (delta.X + delta.Y)), new Vector2(CameraAngleCos, CameraAngleSin));
+    }
+
+    private bool ShouldSkipIngameIcon(BaseIcon icon)
+    {
+        if (!icon.HasIngameIcon || icon is CustomIcon)
+            return false;
+
+        if (Settings.DrawReplacementsForGameIconsWhenOutOfRange && !icon.Entity.IsValid)
+            return false;
+
+        var path = icon.Entity.Path ?? string.Empty;
+        return !Settings.AlwaysShownIngameIcons.Content.Any(x => global::MinimapIcons.IconsBuilder.IconsBuilder.GetRegex(x.Value).IsMatch(path)) &&
+               (icon is not MonsterIcon || !global::MinimapIcons.IconsBuilder.IconsBuilder.ShouldTreatAsMonsterWithIcon(path, Settings.IconsBuilderSettings));
     }
 }
 


### PR DESCRIPTION
- Introduced `ShouldSkipIngameIcon` method in `MinimapIcons` to encapsulate the logic for determining whether an icon should be skipped based on its properties and settings.
- Updated conditions in `IconsBuilder` to utilize the new method, enhancing readability.
- Added `ShouldTreatAsMonsterWithIcon` method to centralize the logic for identifying monster icons, improving code reuse and clarity.